### PR TITLE
multi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.vscode

--- a/README.md
+++ b/README.md
@@ -4,9 +4,23 @@
 ![Crates.io](https://img.shields.io/crates/v/cosync)
 ![Crates.io](https://img.shields.io/crates/l/cosync)
 
-This crate provides a single-threaded, sequential, parameterized async runtime. In other words, this creates *coroutines*, specifically targeting video game logic, though `cosync` is suitable for creating any sequences of directions which take time.
+This crate provides a single-threaded, parameterized async runtime. In other words, this creates *coroutines*, specifically targeting video game logic, though `cosync` is suitable for creating any sequences of directions which take time.
 
-Here's a basic `Cosync` example:
+## Quick Start
+
+To install, add the following to your Cargo.toml:
+
+```toml
+cosync = "0.2.1"
+```
+
+or run
+
+```sh
+cargo add cosync
+```
+
+You can make and use a `Cosync` as follows:
 
 ```rust
 use cosync::{Cosync, CosyncInput};
@@ -23,7 +37,7 @@ fn main() {
     });
 
     let mut value = 0;
-    cosync.run_until_stall(&mut value);
+    cosync.run(&mut value);
 
     // okay, we ran our future, and since it has no awaits, we know
     // it will have completed!
@@ -54,10 +68,32 @@ cosync_dyn.queue(|mut input| async move {
 });
 ```
 
-`Cosync` is **not** multithreaded, nor parallel -- it works entirely sequentially. Think of it as a useful way of expressing code that is multistaged and takes *time* to complete, that you want to do *later*. Moving cameras, staging actors, and performing animations often work well with `Cosync`. Loading asset files, doing mathematical computations, or doing IO should be done by more easily multithreaded runtimes such as [switchyard](https://github.com/BVE-Reborn/switchyard).
+## Overview
 
-This crate exposes two methods for driving the runtime: `run_until_stall` and `run_blocking`. You generally want `run_until_stall`, which attempts process as much of the queue as it can, until it cannot (ie, a future returns `Poll::Pending`), at which point control is returned to the caller.
+`Cosync` is **not** multithreaded or parallel -- it works fundamentally sequentially, though if provided more than one task, it will try to make progress on all of them. In this library, we refer to that idea as "concurrent" tasks, though once again, they are fundamentally single-threaded, and therefore, sequential.
+
+A `Cosync` is a useful way of expressing code that is multistaged, that takes *time* to complete, or that you want to do *later*. Moving cameras, staging actors, performing animations, or reacting to button presses often work well with `Cosync`. Loading asset files, doing mathematical computations, or doing IO should be done by more easily multithreaded runtimes such as [switchyard](https://github.com/BVE-Reborn/switchyard).
+
+This crate exposes two methods for driving the runtime: `run` and `run_blocking`. You generally want `run`, which attempts process as much of the queue as it can, until it cannot (ie, a future returns `Poll::Pending`), at which point control is returned to the caller.
 
 There are three ways to make new tasks. First, the `Cosync` struct itself has a `queue` method on it. Secondly, each task gets a `CosyncInput<T>` as a parameter, which has `get` (to get access to your `&mut T`) and `queue` to queue another task (which is at the end of the queue, not necessarily after the task which added it). Lastly, you can create a `CosyncQueueHandle` with `Cosync::create_queue_handle` which is `Send` and can be given to other threads to create new tasks for the `Cosync`.
 
-This crate depends on only `std` and `parking_lot`. It is in an early state of development, but is in production ready state right now.
+## Waiting Around
+
+`Cosync` includes the utility function `sleep_ticks`. This function returns a future which you can `.await`, which will continue the task after the specified number of ticks. A `tick` occurs every time `run` or `run_blocking` is called.
+
+Right now, it is implemented simply, but in the future, it will become better. This can allow for more efficient code in the future.
+
+## Waking Tasks
+
+Tasks which return a `Poll::Pending` must also wake the waker, with `cx.waker().wake_by_ref()` at some point in the future. This is temporary in the library -- likely in the future, all tasks will always assume they are awake.
+
+## Handling Multiple Tasks
+
+If two or more tasks are queued, the next time `run` is called, progress will be made on both of them. Cosync will *always* do work on the first queued task, and then, whether or not the first task completes (ie, returns `Poll::Result(())`), do work on the second task.
+
+## `SerialCosync`
+
+In the early days of this library, this wasn't the case. Instead, `Cosync` would do only *one* task at a time, and if, and only if, a task returned `Poll::Result(())` would `Cosync` move onto the next task. This is extremely useful in certain contexts, so a modified `Cosync` with that behavior is available as `SerialCosync`. It has the same API, though slightly modified to reflect that only task is running at a time. See `examples/serial.rs` for an example of it in practice.
+
+This crate depends on only `std`. It is in an early state of development, but is in production ready state right now.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This crate provides a single-threaded, parameterized async runtime. In other wor
 To install, add the following to your Cargo.toml:
 
 ```toml
-cosync = "0.2.1"
+cosync = { git = https://github.com/sanbox-irl/cosync }
 ```
 
 or run

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -46,7 +46,7 @@ fn main() {
 
     // this is your main loop
     loop {
-        game.cosync.run_until_stall(&mut game.world);
+        game.cosync.run(&mut game.world);
 
         if game.world.cancel_game {
             break;

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -1,0 +1,3 @@
+fn main() {
+    todo!("needs to be implemented before release")
+}

--- a/src/futures/futures_unordered.rs
+++ b/src/futures/futures_unordered.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::UnsafeCell,
-    cmp,
     fmt::{self, Debug},
     future::Future,
     marker::PhantomData,
@@ -9,8 +8,8 @@ use std::{
     ptr,
     sync::{
         atomic::{
-            AtomicBool, AtomicPtr,
-            Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst},
+            AtomicBool, AtomicPtr, AtomicUsize,
+            Ordering::{self, AcqRel, Acquire, Relaxed, Release, SeqCst},
         },
         Arc, Weak,
     },
@@ -18,33 +17,6 @@ use std::{
 };
 
 use super::{atomic_waker::AtomicWaker, Dequeue, Iter, IterMut, IterPinMut, IterPinRef, ReadyToRunQueue, Task};
-
-/// Constant used for a `FuturesUnordered` to determine how many times it is
-/// allowed to poll underlying futures without yielding.
-///
-/// A single call to `poll_next` may potentially do a lot of work before
-/// yielding. This happens in particular if the underlying futures are awoken
-/// frequently but continue to return `Pending`. This is problematic if other
-/// tasks are waiting on the executor, since they do not get to run. This value
-/// caps the number of calls to `poll` on underlying futures a single call to
-/// `poll_next` is allowed to make.
-///
-/// The value itself is chosen somewhat arbitrarily. It needs to be high enough
-/// that amortize wakeup and scheduling costs, but low enough that we do not
-/// starve other tasks for long.
-///
-/// See also https://github.com/rust-lang/futures-rs/issues/2047.
-///
-/// Note that using the length of the `FuturesUnordered` instead of this value
-/// may cause problems if the number of futures is large.
-/// See also https://github.com/rust-lang/futures-rs/pull/2527.
-///
-/// Additionally, polling the same future twice per iteration may cause another
-/// problem. So, when using this value, it is necessary to limit the max value
-/// based on the length of the `FuturesUnordered`.
-/// (e.g., `cmp::min(self.len(), YIELD_EVERY)`)
-/// See also https://github.com/rust-lang/futures-rs/pull/2333.
-const YIELD_EVERY: usize = 32;
 
 /// A set of futures which may complete in any order.
 ///
@@ -56,6 +28,7 @@ const YIELD_EVERY: usize = 32;
 pub struct FuturesUnordered<Fut> {
     ready_to_run_queue: Arc<ReadyToRunQueue<Fut>>,
     pub(super) head_all: AtomicPtr<Task<Fut>>,
+    poll_counter: usize,
 }
 
 #[allow(clippy::non_send_fields_in_send_ty)]
@@ -122,6 +95,7 @@ impl<Fut> FuturesUnordered<Fut> {
             next_ready_to_run: AtomicPtr::new(ptr::null_mut()),
             queued: AtomicBool::new(true),
             ready_to_run_queue: Weak::new(),
+            last_polled: AtomicUsize::new(1),
         });
         let stub_ptr = Arc::as_ptr(&stub);
         let ready_to_run_queue = Arc::new(ReadyToRunQueue {
@@ -134,6 +108,7 @@ impl<Fut> FuturesUnordered<Fut> {
         Self {
             head_all: AtomicPtr::new(ptr::null_mut()),
             ready_to_run_queue,
+            poll_counter: 0,
         }
     }
 
@@ -167,6 +142,7 @@ impl<Fut> FuturesUnordered<Fut> {
             next_ready_to_run: AtomicPtr::new(ptr::null_mut()),
             queued: AtomicBool::new(true),
             ready_to_run_queue: Arc::downgrade(&self.ready_to_run_queue),
+            last_polled: AtomicUsize::new(0),
         });
 
         // Right now our task has a strong reference count of 1. We transfer
@@ -388,27 +364,27 @@ impl<Fut> FuturesUnordered<Fut> {
     }
 }
 
-impl<Fut: Future> FuturesUnordered<Fut> {
-    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Fut::Output>> {
-        // See YIELD_EVERY docs　for more.
-        let yield_every = cmp::min(self.len(), YIELD_EVERY);
+impl<Fut: Future<Output = ()>> FuturesUnordered<Fut> {
+    /// Increments the poll counter. Should be called along with `poll_next`!
+    pub fn increment_counter(&mut self) {
+        // add to our counter
+        self.poll_counter += 1;
+    }
 
-        // Keep track of how many child futures we have polled,
-        // in case we want to forcibly yield.
-        let mut polled = 0;
-
+    pub fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         // Ensure `parent` is correctly set.
         self.ready_to_run_queue.waker.register(cx.waker());
+
+        let mut initial_task_id = None;
 
         loop {
             // Safety: &mut self guarantees the mutual exclusion `dequeue`
             // expects
-            let task = match unsafe { self.ready_to_run_queue.dequeue() } {
+            let task_ptr = match unsafe { self.ready_to_run_queue.dequeue() } {
                 Dequeue::Empty => {
                     if self.is_empty() {
-                        // We can only consider ourselves terminated once we
-                        // have yielded a `None`
-                        return Poll::Ready(None);
+                        // this means we're out of tasks
+                        return Poll::Ready(());
                     } else {
                         return Poll::Pending;
                     }
@@ -423,12 +399,12 @@ impl<Fut: Future> FuturesUnordered<Fut> {
                 Dequeue::Data(task) => task,
             };
 
-            debug_assert!(task != self.ready_to_run_queue.stub());
+            debug_assert!(task_ptr != self.ready_to_run_queue.stub());
 
             // Safety:
             // - `task` is a valid pointer.
             // - We are the only thread that accesses the `UnsafeCell` that contains the future
-            let future = match unsafe { &mut *(*task).future.get() } {
+            let future = match unsafe { &mut *(*task_ptr).future.get() } {
                 Some(future) => future,
 
                 // If the future has already gone away then we're just
@@ -442,7 +418,7 @@ impl<Fut: Future> FuturesUnordered<Fut> {
                     // queue.
 
                     // Safety: `task` is a valid pointer
-                    let task = unsafe { Arc::from_raw(task) };
+                    let task = unsafe { Arc::from_raw(task_ptr) };
 
                     // Double check that the call to `release_task` really
                     // happened. Calling it required the task to be unlinked.
@@ -455,13 +431,36 @@ impl<Fut: Future> FuturesUnordered<Fut> {
             };
 
             // Safety: `task` is a valid pointer
-            let task = unsafe { self.unlink(task) };
+            let task = unsafe { self.unlink(task_ptr) };
 
             // Unset queued flag: This must be done before polling to ensure
             // that the future's task gets rescheduled if it sends a wake-up
             // notification **during** the call to `poll`.
             let prev = task.queued.swap(false, SeqCst);
             assert!(prev);
+
+            if task.last_polled.load(Ordering::Relaxed) >= self.poll_counter {
+                // we put it back to true -- this is because we want to make sure to use the flag to find errors.
+                task.queued.swap(true, SeqCst);
+
+                let task_ptr = self.link(task);
+                self.ready_to_run_queue.enqueue(task_ptr);
+
+                match initial_task_id {
+                    Some(iti) => {
+                        if iti == task_ptr as usize {
+                            return Poll::Pending;
+                        } else {
+                            continue;
+                        }
+                    }
+                    None => {
+                        initial_task_id = Some(task_ptr as usize);
+                        continue;
+                    }
+                }
+            }
+            task.last_polled.store(self.poll_counter, Ordering::Relaxed);
 
             // We're going to need to be very careful if the `poll`
             // method below panics. We need to (a) not leak memory and
@@ -509,27 +508,22 @@ impl<Fut: Future> FuturesUnordered<Fut> {
 
                 // Safety: We won't move the future ever again
                 let future = unsafe { Pin::new_unchecked(future) };
-
                 future.poll(&mut cx)
             };
-            polled += 1;
 
             match res {
                 Poll::Pending => {
+                    // change the ordering so we don't see it again this cycle...
                     let task = bomb.task.take().unwrap();
-                    bomb.queue.link(task);
+                    let task_ptr = bomb.queue.link(task);
 
-                    if polled == yield_every {
-                        // We have polled a large number of futures in a row without yielding.
-                        // To ensure we do not starve other tasks waiting on the executor,
-                        // we yield here, but immediately wake ourselves up to continue.
-                        cx.waker().wake_by_ref();
-                        return Poll::Pending;
+                    // we're using pointers as usize because we live dangerously
+                    if initial_task_id.is_none() {
+                        initial_task_id = Some(task_ptr as usize);
                     }
-                    continue;
                 }
-                Poll::Ready(output) => return Poll::Ready(Some(output)),
-            }
+                Poll::Ready(()) => {}
+            };
         }
     }
 }

--- a/src/futures/iter.rs
+++ b/src/futures/iter.rs
@@ -1,8 +1,5 @@
-use super::task::Task;
-use super::FuturesUnordered;
-use core::marker::PhantomData;
-use core::pin::Pin;
-use core::sync::atomic::Ordering::Relaxed;
+use super::{task::Task, FuturesUnordered};
+use core::{marker::PhantomData, pin::Pin, sync::atomic::Ordering::Relaxed};
 
 /// Mutable iterator over all futures in the unordered set.
 #[derive(Debug)]

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -65,8 +65,8 @@ mod atomic_waker;
 mod iter;
 
 // mod iter;
-use std::sync::Arc;
 pub use self::iter::{IntoIter, Iter, IterMut, IterPinMut, IterPinRef};
+use std::sync::Arc;
 
 mod futures_unordered;
 pub use self::futures_unordered::FuturesUnordered;

--- a/src/futures/ready_to_run_queue.rs
+++ b/src/futures/ready_to_run_queue.rs
@@ -34,7 +34,7 @@ impl<Fut> ReadyToRunQueue<Fut> {
     /// The enqueue function from the 1024cores intrusive MPSC queue algorithm.
     pub(super) fn enqueue(&self, task: *const Task<Fut>) {
         unsafe {
-            debug_assert!((*task).queued.load(Relaxed));
+            // debug_assert!((*task).queued.load(Relaxed));
 
             // This action does not require any coordination
             (*task).next_ready_to_run.store(ptr::null_mut(), Relaxed);

--- a/src/futures/waker_ref.rs
+++ b/src/futures/waker_ref.rs
@@ -45,7 +45,7 @@ impl Deref for WakerRef<'_> {
 pub fn waker_ref<T: ArcWake>(this: &Arc<T>) -> WakerRef<'_> {
     // simply copy the pointer instead of using Arc::into_raw,
     // as we don't actually keep a refcount by using ManuallyDrop.<
-    let ptr = (&**this as *const T) as *const ();
+    let ptr = Arc::as_ptr(this) as *const ();
 
     let waker = ManuallyDrop::new(unsafe { Waker::from_raw(RawWaker::new(ptr, waker_vtable::<T>())) });
     WakerRef::new_unowned(waker)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,8 @@ impl<T: 'static + ?Sized> Cosync<T> {
         unlock_mutex(&self.queue).incoming.clear();
     }
 
-    /// Adds a new Task into the Pool directly.
+    /// Adds a new Task into the Pool directly. This does not queue it at all, for the sake of
+    /// saving a mutex unlock call.
     pub fn queue<Task, Out>(&mut self, task: Task) -> CosyncTaskId
     where
         Task: FnOnce(CosyncInput<T>) -> Out + Send + 'static,
@@ -1165,60 +1166,4 @@ mod tests {
         // it's still 1 because we cancelled the task which would have otherwise gotten it to 2
         assert_eq!(value, 1);
     }
-
-    // #[test]
-    // #[allow(clippy::needless_late_init)]
-    // fn pool_remains_sequential() {
-    //     // notice that value is declared here
-    //     let mut value;
-
-    //     let mut executor: Cosync<i32> = Cosync::new();
-    //     executor.queue(move |mut input| async move {
-    //         *input.get() = 10;
-
-    //         sleep_ticks(100).await;
-
-    //         *input.get() = 20;
-    //     });
-
-    //     executor.queue(move |mut input| async move {
-    //         assert_eq!(*input.get(), 20);
-    //     });
-
-    //     value = 0;
-    //     executor.run_until_stall(&mut value);
-    // }
-
-    // #[test]
-    // fn cancelling_a_task() {
-    //     let mut cosync: Cosync<i32> = Cosync::new();
-
-    //     cosync.queue(|mut input| async move {
-    //         *input.get() += 1;
-
-    //         sleep_ticks(1).await;
-
-    //         *input.get() += 1;
-    //     });
-
-    //     let mut value = 0;
-
-    //     cosync.run_until_stall(&mut value);
-
-    //     assert_eq!(value, 1);
-
-    //     cosync.clear_running();
-
-    //     cosync.run_until_stall(&mut value);
-
-    //     // it's still 1 because we cancelled the task which would have otherwise gotten it to 2
-    //     assert_eq!(value, 1);
-
-    //     assert!(cosync.is_empty());
-    //     let id = cosync.queue(|_| async {});
-    //     assert_eq!(cosync.len(), 1);
-    //     let success = cosync.unqueue_task(id);
-    //     assert!(success);
-    //     assert!(cosync.is_empty());
-    // }
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,0 +1,171 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::{
+    create_future_object, next_cosync_task_id, unlock_mutex, Cosync, CosyncInput, CosyncQueueHandle, CosyncTaskId,
+};
+
+/// A `SerialCosync` has the same API as `Cosync`, but *only* runs one task at a time,
+/// unlike `Cosync`, which runs all tasks concurrently. This means that in `SerialCosync`
+/// a task must fully complete (return `Pending::Result`) before the next queued task is ran,
+/// and so on and so on.
+#[derive(Debug)]
+pub struct SerialCosync<T: ?Sized>(Cosync<T>);
+
+impl<T: ?Sized + 'static> SerialCosync<T> {
+    /// Creates a new, empty [SerialCosync].
+    pub fn new() -> Self {
+        Self(Cosync::new())
+    }
+
+    /// Returns the `number of tasks queued + 1` if there is any task being executed.
+    ///
+    /// This *includes* the task currently being executed. Use [is_running_any] to see if there is a
+    /// task currently being executed.
+    ///
+    /// [is_running_any]: Self::is_running_any
+    pub fn len(&self) -> usize {
+        self.is_running_any() as usize + unlock_mutex(&self.0.queue).incoming.len()
+    }
+
+    /// Returns true if nothing is being executed and the queue is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns true if the `SerialCosync` is executing a task. In general, that means the task has
+    /// return `Pending` at least once after called `run_until_stall`.
+    pub fn is_running_any(&self) -> bool {
+        self.0.is_running_any()
+    }
+
+    /// Returns true if `SerialCosync` is executing the given `CosyncTaskId`.
+    pub fn is_running(&self, task_id: CosyncTaskId) -> bool {
+        self.0.is_running(task_id)
+    }
+
+    /// Creates a queue handle which can be used to spawn tasks.
+    pub fn create_queue_handle(&self) -> CosyncQueueHandle<T> {
+        self.0.create_queue_handle()
+    }
+
+    /// Tries to force unqueueing a task.
+    ///
+    /// If that task is already being ran, and you want to external cancel it, run
+    /// `stop_running_task`. To see if a task is currently running, see `is_running`.
+    ///
+    /// This returns `true` on success and `false` on failure.
+    pub fn unqueue_task(&mut self, task_id: CosyncTaskId) -> bool {
+        let incoming = &mut unlock_mutex(&self.queue).incoming;
+        let Some(index) = incoming.iter().position(|future_obj| future_obj.1 == task_id) else { return false };
+        incoming.remove(index);
+
+        true
+    }
+
+    /// Stops a currently running task of the given id.
+    ///
+    /// If that task is only queued, but `run` hasn't been called on the Cosync, then it's only
+    /// queued -- run `unqueue_task` instead. To see if a task is currently running, see
+    /// `is_running`.
+    pub fn stop_running_task(&mut self, task_id: CosyncTaskId) -> bool {
+        // check the pool
+        for f in self.pool.iter_mut() {
+            if f.1 == task_id {
+                // we replace that task with an empty one instead. This is a hack...
+                // which might work?
+                f.0 = Box::pin(async move {});
+
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Cosync keeps track of running task(s) and queued task(s). You can use this function to clear
+    /// only the running tasks. This generally is a bad idea, producing complicated logic. In
+    /// general, it's much easier to cancel internally in a future.
+    ///
+    /// For Cosync's which are `PollMultiple`, this will cancel all running tasks. It is not
+    /// possible to only cancel a single running task right now. If you need that, please submit
+    /// an issue.
+    pub fn clear_running(&mut self) {
+        self.pool.clear();
+    }
+
+    /// Clears all queued tasks. Currently running tasks are unaffected. All `CosyncQueueHandler`s
+    /// are still valid.
+    pub fn clear_queue(&mut self) {
+        unlock_mutex(&self.queue).incoming.clear();
+    }
+
+    /// This clears all running tasks and all queued tasks.
+    ///
+    /// All `CosyncQueueHandler`s are still valid.
+    pub fn clear(&mut self) {
+        self.pool.clear();
+        unlock_mutex(&self.queue).incoming.clear();
+    }
+
+    /// Adds a new Task into the Pool directly.
+    pub fn queue<Task, Out>(&mut self, task: Task) -> CosyncTaskId
+    where
+        Task: FnOnce(CosyncInput<T>) -> Out + Send + 'static,
+        Out: Future<Output = ()> + Send,
+    {
+        let cosync_input = CosyncInput(self.0.create_queue_handle());
+        let id = next_cosync_task_id(&self.0.queue);
+
+        let mut lock = unlock_mutex(&self.0.queue);
+        lock.incoming.push_back(create_future_object(task, cosync_input, id));
+
+        id
+    }
+
+    /// Runs all tasks to completion, possibly looping forever.
+    pub fn run_blocking(&mut self, parameter: &mut T) {
+        super::run_blocking(self.0.data, parameter, |ctx| Self::poll_pool(&mut self.0, ctx));
+    }
+
+    /// Runs all tasks in the queue and returns if no more progress can be made
+    /// on any task.
+    pub fn run_until_stall(&mut self, parameter: &mut T) {
+        super::run_until_stall(self.0.data, parameter, |ctx| Self::poll_pool(&mut self.0, ctx))
+    }
+
+    fn poll_pool(cosync: &mut Cosync<T>, cx: &mut Context<'_>) -> Poll<()> {
+        loop {
+            cosync.pool.increment_counter();
+            // try to execute the next ready future
+            let pinned_pool = Pin::new(&mut cosync.pool);
+            let ret = pinned_pool.poll_next(cx);
+
+            // no queued tasks; we may be done
+            match ret {
+                // this means an inner task is pending
+                Poll::Pending => return Poll::Pending,
+                // the pool was empty already, or we just completed that task.
+                Poll::Ready(()) => {
+                    // grab our next task...
+                    if let Some(task) = unlock_mutex(&cosync.queue).incoming.pop_front() {
+                        cosync.pool.push(task);
+
+                        // and now let's re-run this bad boy
+                    } else {
+                        return Poll::Ready(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T: ?Sized + 'static> Default for SerialCosync<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
- initial work. will require fiddling in futuredunordered
- removed some stuff we don't use
- making progress, passed tests!
- better panic nomenclature
- editing gitignore
- miri gets mad if it's not like this
- it's all concurrent, all the time
- gettin there!
- okay, we're ready to go
- some readme work
- changes to the readme
- killed `run_until_stall` too
